### PR TITLE
Issue #48: hook_config_info must return info.

### DIFF
--- a/og.module
+++ b/og.module
@@ -509,6 +509,7 @@ function og_config_info() {
     'label' => t('Organic groups settings'),
     'group' => t('Configuration'),
   );
+  return $prefixes;
 }
 
 /**

--- a/og_context/og_context.module
+++ b/og_context/og_context.module
@@ -407,6 +407,7 @@ function og_context_config_info() {
     'label' => t('Organic groups context settings'),
     'group' => t('Configuration'),
   );
+  return $prefixes;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/og/issues/48