### PR TITLE
Issue #32. Fix OgUiUserPermissionsTestCase

### DIFF
--- a/og_ui/og_ui.test
+++ b/og_ui/og_ui.test
@@ -23,7 +23,11 @@ class OgUiUserPermissionsTestCase extends BackdropWebTestCase {
     $web_user = $this->backdropCreateUser();
     $this->backdropLogin($admin_user);
 
-    // Create a group.
+    // Create the 'main' og_entity_test_type bundle definition.
+    $entity_type = entity_create('og_entity_test_type', array('name' => 'main'));
+    $entity_type->save();
+
+    // Create a group of bundle 'main'.
     $entity1 = entity_create('og_entity_test', array('name' => 'main', 'uid' => $admin_user->uid));
     $wrapper = entity_metadata_wrapper('og_entity_test', $entity1);
     $wrapper->{OG_GROUP_FIELD}->set(1);

--- a/tests/og_entity_test/og_entity_test.entity.inc
+++ b/tests/og_entity_test/og_entity_test.entity.inc
@@ -86,7 +86,7 @@ class EntityClassType extends Entity {
    * Implements EntityInterface::entityType().
    */
   public function entityType() {
-    return 'og_entity_test';
+    return 'og_entity_test_type';
   }
 
   /**


### PR DESCRIPTION
Part of #32.

Since this PR addresses the same issues as PR #58, do not apply @indigoxela's #58 , as that PR substantially modified this test to avoid using og_entity_test.

This RESTORES most of the original use of og_entity_test in this test and fixes a few lines that were needed for these to pass.

