### PR TITLE
Issue #67. Test multiple audience fields with EFQ

### DIFF
--- a/tests/og.test
+++ b/tests/og.test
@@ -1268,16 +1268,42 @@ class OgEntityFieldQueryTestCase extends OgTestBase {
 
     $this->assertEqual(array_keys($result['node']), array($node->nid), 'Single group audience query is correct.');
 
+    // TODO: the following lines were from the original test. They are commented
+    // out because of a bug in OG's og_query_og_membership_alter. See 
+    // https://www.drupal.org/project/og/issues/2039903
+    // Let's keep an eye on that D7 issue and reactivate this test when
+    // that's solved.
+
+    // Multiple group audience.
+    // $query = new EntityFieldQuery();
+    // $result = $query
+    //   ->entityCondition('entity_type', 'node')
+    //   ->propertyCondition('type', $node->type)
+    //   ->fieldCondition('og_node', 'target_id', $group2->nid)
+    //   ->fieldCondition('og_og_entity_test', 'target_id', $group1->pid)
+    //   ->execute();
+
+    // In the meantime, we provide an alternative way to test this
+    // following the recommendation posted here:
+    // https://www.drupal.org/project/og/issues/2039903#comment-10010179
+
     // Multiple group audience.
     $query = new EntityFieldQuery();
-    $result = $query
+    $result1 = $query
       ->entityCondition('entity_type', 'node')
       ->propertyCondition('type', $node->type)
       ->fieldCondition('og_node', 'target_id', $group2->nid)
+      ->execute();
+
+    $query = new EntityFieldQuery();
+    $result2 = $query
+      ->entityCondition('entity_type', 'node')
+      ->propertyCondition('type', $node->type)
       ->fieldCondition('og_og_entity_test', 'target_id', $group1->pid)
       ->execute();
 
-    $this->assertEqual(array_keys($result['node']), array($node->nid), 'Multiple group audience query is correct.');
+    $result_ids = array_intersect(array_keys($result1['node']), array_keys($result2['node']));
+    $this->assertEqual($result_ids, array($node->nid), 'Multiple group audience query is correct.');
 
     // Single group audience first, with another non-audience field.
     $query = new EntityFieldQuery();


### PR DESCRIPTION
Fixes #67.

Because of a bug in OG reported in #67, this is an alternative way to test EntityFieldQuery with multiple OG audience fields - basically using two EFQs and intersecting them.

If this issue is fixed, it'd be good to revert to the original way of testing this.