### PR TITLE
Issue #32. Check that group field type is not empty

### DIFF
--- a/og.module
+++ b/og.module
@@ -2441,7 +2441,7 @@ function og_get_entity_groups($entity_type = 'user', $entity = NULL, $states = a
  */
 function og_is_group_audience_field($field_name) {
   $field = field_info_field($field_name);
-  return $field['type'] == 'entityreference' && ($field['settings']['handler'] == 'og' || strpos($field['settings']['handler'], 'og_') === 0);
+  return !empty($field['type']) && $field['type'] == 'entityreference' && ($field['settings']['handler'] == 'og' || strpos($field['settings']['handler'], 'og_') === 0);
 }
 
 /**


### PR DESCRIPTION
Fixes #32 for `OgGroupAndUngroup` tests

This small tweak of `og_is_group_audience_field()` is necessary in PHP 7.4+ in order for `OgGroupAndUngroup` to pass.

This tweak also helps catch typos in field names, or wrong field names - it avoids throwing an Exception for a null array offset in PHP 7.4+