### PR TITLE
Issue #98. Improved description of the 'OG non members publishing' self test

### DIFF
--- a/tests/og.tests.info
+++ b/tests/og.tests.info
@@ -78,7 +78,7 @@ file = og.test
 
 [OgNonMembersPublishingContentTestCase]
 name = OG non members publishing
-description = Grant access to non members users publishing content with the group passed in the query string.
+description = Grant access to non members users publishing content with the group passed in the query string. <a href="https://backdropcms.org/project/entityreference_prepopulate/">Entity reference prepopulate module</a> is required!
 group = Organic groups
 file = og.test
 


### PR DESCRIPTION
Fixes #98. Improved description of the 'OG non members publishing' self test - Issue https://github.com/backdrop-contrib/og/issues/98