### PR TITLE
Issue #34. Correctly remove field data, info and instance when uninstalling

### DIFF
--- a/og.install
+++ b/og.install
@@ -11,7 +11,8 @@
 function og_install() {
   // Add "User request" to the default group membership type.
   $field_name = OG_MEMBERSHIP_REQUEST_FIELD;
-  if (!field_info_field($field_name)) {
+  $field_info = field_info_field($field_name);
+  if (empty($field_info) || !empty($field_info['deleted']))  {
     $field = array(
       'field_name' => $field_name,
       'type' => 'text_long',
@@ -41,13 +42,23 @@ function og_install() {
  * Implements hook_uninstall().
  */
 function og_uninstall() {
-  // Delete OG-core fields.
+
+  // Take care of deleting field instances attached to bundles of og_membership.
+  // Query the database, since field_info_instances() will not include bundles
+  // of og_membership at this point.
+  $query = db_select('og_membership_type', 'ogt');
+  $query->addField('ogt', 'name');
+  $bundles = $query->execute()->fetchCol(0);
+  foreach ($bundles as $bundle) {
+    // Instruct field.module to remove fields attached to these bundles.
+    field_attach_delete_bundle('og_membership', $bundle);
+  }
+
+  // Remove all instances attached to core entities.
   $og_fields = array(
     'group_group',
     'og_description',
-    'og_membership_request',
   );
-
   foreach (field_info_instances() as $bundles) {
     foreach ($bundles as $instances) {
       foreach ($instances as $instance) {
@@ -64,8 +75,8 @@ function og_uninstall() {
       }
     }
   }
+  field_purge_batch(100);
 }
-
 
 /**
  * Implements hook_schema().

--- a/og.module
+++ b/og.module
@@ -3448,7 +3448,7 @@ function og_create_field($field_name, $entity_type, $bundle, $og_field = array()
   $field = field_info_field($field_name);
   // Allow overriding the field name.
   $og_field['field']['field_name'] = $field_name;
-  if (empty($field)) {
+  if (empty($field) || !empty($field['deleted'])) {
     $field = field_create_field($og_field['field']);
   }
 


### PR DESCRIPTION
Fixes #34.

Explanation: there were two problems:
1. Field `og_membership_request` not being removed at all (field info, field instance and data). This happens also in the D7 version. The entity to which it's attached, `og_membership`, has been deleted and therefore the removal of the field needed some special treatment
2. Other OG fields attached to core entities were marked as deleted (info and instance), but the table was not removed. Running cron took care of removing everything. So, to solve this without waiting until cron ran, I used `field_purge_batch` at the end of the uninstall hook, as recommended in some D7 posts.

Tested thoroughly - working fine.