### PR TITLE
Fixed php 8.5 deprecated non-canonical cast (boolean).

### DIFF
--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -435,7 +435,7 @@ function og_ui_access_bundle_role($rid) {
   }
 
   $role = og_role_load($rid);
-  return (boolean) $role;
+  return (bool) $role;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/og/issues/162